### PR TITLE
Fix popular names API

### DIFF
--- a/app/api/popular/route.ts
+++ b/app/api/popular/route.ts
@@ -29,6 +29,7 @@ export async function GET(request: NextRequest) {
         const baseQuery = db
             .select({
                 name: names.name,
+                sex: names.sex,
                 total: sql`SUM(${names.amount})`.as('total')
             })
             .from(names);
@@ -38,8 +39,8 @@ export async function GET(request: NextRequest) {
             : baseQuery;
 
         const finalQuery = queryWithConditions
-            .groupBy(names.name)
-            .orderBy(desc(sql`total`))
+            .groupBy(names.name, names.sex)
+            .orderBy(desc(sql`total`), names.sex)
             .limit(500);
 
         const popularNames = await finalQuery;

--- a/app/popular/page.tsx
+++ b/app/popular/page.tsx
@@ -53,7 +53,7 @@ export default function PopularNamesPage() {
     const fetchPopularNames = async () => {
         setIsLoading(true);
         try {
-                let apiUrl = `/api/year?year=${year}`;
+                let apiUrl = `/api/popular?year=${year}`;
                 if (sex !== "all") {
                     apiUrl += `&sex=${sex}`;
                 }


### PR DESCRIPTION
Fixes #6

Update `/api/popular` endpoint to return aggregated data for names and sex when 'all' is passed as the year.

* Modify `app/api/popular/route.ts` to include `names.sex` in the `groupBy`, `select`, and `orderBy` clauses.
* Update `app/popular/page.tsx` to correct the API URL in the `fetchPopularNames` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/aramshiva/nomen/pull/9?shareId=875f3b64-ccb4-40f7-bf6f-fbcb6a3970f9).